### PR TITLE
README update, flac glob and  empty np.where bug fix

### DIFF
--- a/fix_piano_in_162.py
+++ b/fix_piano_in_162.py
@@ -3,24 +3,37 @@ import numpy as np
 import argparse
 import glob
 import os
+import traceback
 from tqdm import tqdm
 
 def func(args):
-    files = glob.glob(os.path.join(args.input_dir, '**\*.flac'))
+    flac_pattern = '**\*.flac' if os.name == "nt" else '**/*.flac'
+    files = glob.glob(os.path.join(args.input_dir, flac_pattern), recursive=True)
     print(f'{len(files)} flac files are found.')
+
+    exceps = {}
     for file in files:
         try:
             data, freq = sf.read(file)
-        except:
+            body_idxs = np.where(data > 0.001)
+
+            if len(body_idxs[0]) == 0:
+                print(f'skip {file}')
+                continue
+
+            pos = body_idxs[0][0]
+            if pos > 0:
+                zcpos = np.where(data[0:pos] <= 0.0)[0]
+                if len(zcpos):
+                    zcpos = zcpos[-1] + 1
+                    data = data[zcpos:]
+                    sf.write(file, data, freq, format='FLAC', subtype='PCM_24')
+                    print(f'{zcpos}\t{file[-70:]}')
+        except Exception as e:
+            exceps[file] = traceback.format_exc()
+            print(f'file: {file}\n{exceps[file]}')
             continue
-        pos = np.where(data > 0.001)[0][0]
-        if pos > 0:
-            zcpos = np.where(data[0:pos] <= 0.0)[0]
-            if len(zcpos):
-                zcpos = zcpos[-1] + 1
-                data = data[zcpos:]
-                sf.write(file, data, freq, format='FLAC', subtype='PCM_24')
-                print(f'{zcpos}\t{file[-70:]}')
+    return exceps
 
 def main():
     parser = argparse.ArgumentParser(
@@ -34,7 +47,8 @@ def main():
     parser.set_defaults(func=func)
 
     args = parser.parse_args()
-    args.func(args)
+    exceps = args.func(args)
+    exit(len(exceps))
 
 if __name__ == '__main__':
     main()

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ https://ivyaudio.com/Piano-in-162
 setup:
 
 ```
-pip install numpy, argparse, numpy, tqdm
+pip install numpy argparse numpy tqdm soundfile
 ```
 
 


### PR DESCRIPTION
## Changes
1. Added `pip soundfile`  in readme
2. Recursive glob flac files for both Windows NT/POSIX
    I got `[]` for `glob.glob(os.path.join(args.input_dir, "**/*.flac"))`. Works in Windows...?
3. Caring of `np.where(data > 0.001)` being empty case
4. Exception handling of inner `for file` loop